### PR TITLE
moved react-scripts to dev dependency as it is only requiered during …

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -15,10 +15,12 @@
     "react-redux": "^7.2.1",
     "react-router": "^5.2.0",
     "react-router-dom": "^5.2.0",
-    "react-scripts": "5.0.1",
     "react-sortable-hoc": "^1.11.0",
     "redux": "^4.0.5",
     "redux-thunk": "^2.3.0"
+  },
+  "devDependencies": {
+    "react-scripts": "5.0.1"
   },
   "scripts": {
     "start": "react-scripts start",


### PR DESCRIPTION
…development. semver, one of the dependency of react-script was flagged as vulnerable by github